### PR TITLE
Update qubit_fixing.py

### DIFF
--- a/Code/qiskit_research/protein_folding/qubit_utils/qubit_fixing.py
+++ b/Code/qiskit_research/protein_folding/qubit_utils/qubit_fixing.py
@@ -79,7 +79,7 @@ def _calc_updated_coeffs(
 
 
 def _preset_binary_vals(table_z, has_side_chain_second_bead: bool):
-    main_beads_indices = [0, 1, 2, 3]
+    main_beads_indices = [0] #, 1, 2, 3]
     if not has_side_chain_second_bead:
         main_beads_indices.append(5)
     for index in main_beads_indices:


### PR DESCRIPTION
En este caso, no se fijarían el resto de beads, exceptuando la primera, lo que permite que el sistema vaya a la fase que le corresponda tras la primera bead